### PR TITLE
Fix PHP 8.5 reflection deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  phpunit:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '8.4'
+          - '8.5'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-lock
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit --display-all-issues --fail-on-phpunit-deprecation

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
+        "php": "^8.4",
         "fakerphp/faker": "^1.19",
         "symfony/yaml": "^6.4 || ^7.0"
     },
     "require-dev": {
         "doctrine/common": "^3.0",
         "symfony/property-access": "~5.0|~6.0",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^11.5"
     },
     "autoload": {
         "psr-0": { "Nelmio\\Alice\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    syntaxCheck                 = "false"
-    bootstrap                   = "tests/bootstrap.php">
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="tests/bootstrap.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnWarning="true">
     <testsuites>
         <testsuite name="Fixtures Test Suite">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory>src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -515,7 +515,6 @@ class Base implements LoaderInterface
                     $generatedVal = $this->checkTypeHints($instance, 'set'.$key, $generatedVal);
                     if(!is_callable(array($instance, 'set'.$key))) {
                         $refl = new \ReflectionMethod($instance, 'set'.$key);
-                        $refl->setAccessible(true);
                         $refl->invoke($instance, $generatedVal);
                     } else {
                         $instance->{'set'.$key}($generatedVal);
@@ -523,7 +522,6 @@ class Base implements LoaderInterface
                     $variables[$key] = $generatedVal;
                 } elseif (property_exists($instance, $key)) {
                     $refl = new \ReflectionProperty($instance, $key);
-                    $refl->setAccessible(true);
                     $refl->setValue($instance, $generatedVal);
 
                     $variables[$key] = $generatedVal;
@@ -559,11 +557,11 @@ class Base implements LoaderInterface
         $reflection = new \ReflectionMethod($obj, $method);
         $params = $reflection->getParameters();
 
-        if (!$params[$pNum]->getClass()) {
+        $hintedClass = $this->getClassTypeName($params[$pNum]);
+
+        if (!$hintedClass) {
             return $value;
         }
-
-        $hintedClass = $params[$pNum]->getClass()->getName();
 
         if ($hintedClass === 'DateTime') {
             try {
@@ -585,6 +583,17 @@ class Base implements LoaderInterface
         }
 
         return $value;
+    }
+
+    private function getClassTypeName(\ReflectionParameter $parameter)
+    {
+        $type = $parameter->getType();
+
+        if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        return $type->getName();
     }
 
     private function process($data, array $variables)

--- a/tests/Nelmio/Alice/FixturesTest.php
+++ b/tests/Nelmio/Alice/FixturesTest.php
@@ -48,9 +48,9 @@ class FixturesTest extends TestCase
 
     public function testThatNewLoaderIsCreatedForDifferingOptions()
     {
-        $om = $this->getMock('Doctrine\Persistence\ObjectManager');
+        $om = $this->createMock('Doctrine\Persistence\ObjectManager');
         $om->expects($this->any())
-            ->method('find')->will($this->returnValue(new User()));
+            ->method('find')->willReturn(new User());
 
         $optionsBatch = array(
             // default options
@@ -191,14 +191,12 @@ class FixturesTest extends TestCase
 
     public function testThatExceptionIsThrownForInvalidProvider()
     {
-        $om = $this->getMock('Doctrine\Persistence\ObjectManager');
+        $om = $this->createMock('Doctrine\Persistence\ObjectManager');
         $om->expects($this->any())
-            ->method('find')->will($this->returnValue(new User()));
+            ->method('find')->willReturn(new User());
 
-        $this->setExpectedException(
-            '\InvalidArgumentException',
-            'The provider should be a string or an object, got array instead'
-        );
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The provider should be a string or an object, got array instead');
 
         Fixtures::load(
             __DIR__.'/fixtures/complete.yml',
@@ -270,12 +268,11 @@ class FixturesTest extends TestCase
         $this->assertEquals(42, $user->favoriteNumber);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testLoadWithLogger()
     {
-        $om = $this->getMock('Doctrine\Persistence\ObjectManager');
+        $om = $this->createMock('Doctrine\Persistence\ObjectManager');
+
+        $this->expectException('\RuntimeException');
 
         $objects = Fixtures::load(__DIR__.'/fixtures/basic.php', $om, array(
             'logger' => 'not callable'
@@ -316,7 +313,7 @@ class FixturesTest extends TestCase
 
     protected function getDoctrineManagerMock($objects = null)
     {
-        $om = $this->getMock('Doctrine\Persistence\ObjectManager');
+        $om = $this->createMock('Doctrine\Persistence\ObjectManager');
 
         $om->expects($objects ? $this->exactly($objects) : $this->any())
             ->method('persist');
@@ -325,7 +322,7 @@ class FixturesTest extends TestCase
             ->method('flush');
 
         $om->expects($this->once())
-            ->method('find')->will($this->returnValue(new User()));
+            ->method('find')->willReturn(new User());
 
         return $om;
     }

--- a/tests/Nelmio/Alice/FixturesTest.php
+++ b/tests/Nelmio/Alice/FixturesTest.php
@@ -184,7 +184,6 @@ class FixturesTest extends TestCase
         }
 
         $prop = new \ReflectionProperty('\Nelmio\Alice\Fixtures', 'loaders');
-        $prop->setAccessible(true);
         $loaders = $prop->getValue();
 
         $this->assertEquals(12, count($loaders));

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -79,12 +79,11 @@ class BaseTest extends TestCase
         $this->assertSame($user, $this->loader->getReference('bob'));
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage Reference foo is not defined
-     */
     public function testGetBadReference()
     {
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Reference foo is not defined');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'bob' => array(),
@@ -245,12 +244,11 @@ class BaseTest extends TestCase
         $this->assertEquals($res['bob'], $res['user']->username);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage Property doesnotexist is not defined for reference user1
-     */
     public function testLoadParsesPropertyReferencesDoesNotExist()
     {
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Property doesnotexist is not defined for reference user1');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user1' => array(
@@ -337,12 +335,11 @@ class BaseTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage Reference mask "user*" did not match any existing reference, make sure the object is created after its references
-     */
     public function testLoadFailsMultiReferencesIfNoneMatch()
     {
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Reference mask "user*" did not match any existing reference, make sure the object is created after its references');
+
         $usernames = range('a', 'z');
         $data = array(
             self::GROUP => array(
@@ -458,11 +455,11 @@ class BaseTest extends TestCase
     public function testLoadFetchesScalarIdsForClassHints()
     {
         $owner = new User();
-        $orm = $this->getMockBuilder('Nelmio\Alice\ORMInterface')->getMock();
+        $orm = $this->createMock('Nelmio\Alice\ORMInterface');
         $orm->expects($this->once())
             ->method('find')
             ->with(self::USER, '42')
-            ->will($this->returnValue($owner));
+            ->willReturn($owner);
 
         $loader = $this->createLoader();
         $loader->setORM($orm);
@@ -502,7 +499,7 @@ class BaseTest extends TestCase
         ));
 
         $this->assertNotEquals('<firstName()> <lastName()>', $res['user0']->username);
-        $this->assertRegExp('{^[\w\']+ [\w\']+$}i', $res['user0']->username);
+        $this->assertMatchesRegularExpression('{^[\w\']+ [\w\']+$}i', $res['user0']->username);
     }
 
     public function testLoadParsesFakerDataWithArgs()
@@ -561,15 +558,14 @@ class BaseTest extends TestCase
             ),
         ));
 
-        $this->assertRegExp('{^\d{3} \d{3} \d{3}$}', $res['user0']->username);
+        $this->assertMatchesRegularExpression('{^\d{3} \d{3} \d{3}$}', $res['user0']->username);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Unknown formatter "siren"
-     */
     public function testLoadParsesFakerDataUsesDefaultLocale()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Unknown format "siren"');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user0' => array(
@@ -1020,12 +1016,11 @@ class BaseTest extends TestCase
         $this->assertSame($this->loader->getReference('user')->username, 'my_very_long_name');
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Template user_not_base is not defined
-     */
     public function testInheritedObjectDoesntExist()
     {
+        $this->expectException('\UnexpectedValueException');
+        $this->expectExceptionMessage('Template user_not_base is not defined');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user_base (template)' => array(
@@ -1079,12 +1074,11 @@ class BaseTest extends TestCase
         $this->assertSame($this->loader->getReference('user2')->favoriteNumber, 42);
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Cannot use <current()> out of fixtures ranges
-     */
     public function testCurrentProviderFailsOutOfRanges()
     {
+        $this->expectException('\UnexpectedValueException');
+        $this->expectExceptionMessage('Cannot use <current()> out of fixtures ranges');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user1' => array(
@@ -1094,12 +1088,11 @@ class BaseTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Could not determine how to assign inexistent to a Nelmio\Alice\fixtures\User object
-     */
     public function testArbitraryPropertyNamesFail()
     {
+        $this->expectException('\UnexpectedValueException');
+        $this->expectExceptionMessage('Could not determine how to assign inexistent to a Nelmio\Alice\fixtures\User object');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user1' => array(
@@ -1109,12 +1102,10 @@ class BaseTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage
-     */
     public function testLoadFailsOnConstructorsWithRequiredArgs()
     {
+        $this->expectException('RuntimeException');
+
         $res = $this->loadData(array(
             self::CONTACT => array(
                 'contact' => array(
@@ -1186,11 +1177,9 @@ class BaseTest extends TestCase
         $this->assertSame('alice', $res['user']->username);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage
-     */
     public function testLoadFailsOnInvalidStaticConstructor() {
+        $this->expectException('UnexpectedValueException');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user' => array(
@@ -1200,11 +1189,9 @@ class BaseTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage
-     */
     public function testLoadFailsOnScalarStaticConstructorArgs() {
+        $this->expectException('UnexpectedValueException');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user' => array(
@@ -1214,11 +1201,9 @@ class BaseTest extends TestCase
         ));
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     * @expectedExceptionMessage
-     */
     public function testLoadFailsIfStaticMethodDoesntReturnAnInstance() {
+        $this->expectException('UnexpectedValueException');
+
         $res = $this->loadData(array(
             self::USER => array(
                 'user' => array(
@@ -1327,11 +1312,10 @@ class BaseTest extends TestCase
         $this->assertEquals($usernames, array_unique($usernames));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testUniqueValuesException()
     {
+        $this->expectException('\RuntimeException');
+
         $loader = new Base("en_US", array(new FakerProvider));
         $res = $loader->load(array(
             self::USER => array(
@@ -1395,12 +1379,11 @@ class BaseTest extends TestCase
         $this->assertEquals('foo set by custom setter', $loader->getReference('user')->test_variable);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Setter customNonexistantSetter not found in object
-     */
     public function testCustomNonexistantSetFunction()
     {
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('Setter customNonexistantSetter not found in object');
+
         $this->loadData(
             array(
                 self::USER => array(

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -441,6 +441,42 @@ class BaseTest extends TestCase
         $this->assertInstanceOf('DateTime', $res['group1']->getCreationDate());
     }
 
+    public function testLoadCoercesTimestampForConstructorDateTimeHints()
+    {
+        $res = $this->loadData(array(
+            self::USER => array(
+                'user0' => array(
+                    '__construct' => array(null, null, '1325721600'),
+                ),
+            ),
+        ));
+
+        $this->assertInstanceOf('DateTime', $res['user0']->birthDate);
+        $this->assertEquals('1325721600', $res['user0']->birthDate->format('U'));
+    }
+
+    public function testLoadFetchesScalarIdsForClassHints()
+    {
+        $owner = new User();
+        $orm = $this->getMockBuilder('Nelmio\Alice\ORMInterface')->getMock();
+        $orm->expects($this->once())
+            ->method('find')
+            ->with(self::USER, '42')
+            ->will($this->returnValue($owner));
+
+        $loader = $this->createLoader();
+        $loader->setORM($orm);
+        $res = $loader->load(array(
+            self::GROUP => array(
+                'group0' => array(
+                    'owner' => '42',
+                ),
+            ),
+        ));
+
+        $this->assertSame($owner, $res['group0']->getOwner());
+    }
+
     public function testLoadParsesFakerData()
     {
         $res = $this->loadData(array(

--- a/tests/Nelmio/Alice/Loader/YamlTest.php
+++ b/tests/Nelmio/Alice/Loader/YamlTest.php
@@ -20,7 +20,6 @@ class YamlTest extends TestCase
         $file = __DIR__ . '/../fixtures/include.yml';
         $loader = new \Nelmio\Alice\Loader\Yaml();
         $reflMethod = new \ReflectionMethod($loader, 'parse');
-        $reflMethod->setAccessible(true);
         $data = $reflMethod->invoke($loader, $file);
         $expectedData = array(
             'Nelmio\\Alice\\fixtures\\Product' =>

--- a/tests/Nelmio/Alice/fixtures/User.php
+++ b/tests/Nelmio/Alice/fixtures/User.php
@@ -10,20 +10,21 @@ class User
     public $email;
     public $favoriteNumber;
     public $friends;
+    public $test_variable;
 
-    public function __construct($username = null, $email = null, \DateTime $birthDate = null)
+    public function __construct($username = null, $email = null, ?\DateTime $birthDate = null)
     {
         $this->username = $username;
         $this->email = $email;
         $this->birthDate = $birthDate;
     }
 
-    public static function create($username = null, $email = null, \DateTime $birthDate = null)
+    public static function create($username = null, $email = null, ?\DateTime $birthDate = null)
     {
         return new static($username, $email, $birthDate);
     }
 
-    public static function bogusCreate($username = null, $email = null, \DateTime $birthDate = null)
+    public static function bogusCreate($username = null, $email = null, ?\DateTime $birthDate = null)
     {
     }
 


### PR DESCRIPTION
## Summary
- Remove deprecated `ReflectionMethod::setAccessible()` and `ReflectionProperty::setAccessible()` calls from the loader path.
- Replace `ReflectionParameter::getClass()` usage with `ReflectionParameter::getType()` / `ReflectionNamedType` handling.
- Target the maintained fork at PHP `^8.4`, upgrade the dev test runner to PHPUnit 11, and clean up PHPUnit/PHP deprecations in the tests.
- Add GitHub Actions coverage for PHP 8.4 and 8.5.

## Verification
- `composer validate --strict --no-check-lock`
- `php -l src/Nelmio/Alice/Loader/Base.php && php -l tests/Nelmio/Alice/Loader/BaseTest.php && php -l tests/Nelmio/Alice/FixturesTest.php && php -l tests/Nelmio/Alice/fixtures/User.php && php -l phpunit.xml.dist`
- `rg -n '@expectedException|setExpectedException|getMock\\(|assertRegExp|returnValue\\(|setAccessible|getClass\\(' src tests phpunit.xml.dist || true`
- `vendor/bin/phpunit --display-all-issues --fail-on-phpunit-deprecation` on PHP 8.4.7
- `docker run --rm -v "$PWD":/app -w /app php:8.5-cli php vendor/bin/phpunit --display-all-issues --fail-on-phpunit-deprecation` on PHP 8.5.5

## Notes
- This intentionally stays scoped to PHP 8.4/8.5 readiness for the existing fork. It does not attempt an upstream Alice migration.  I feel like this is the path of least resistance for PHP 8.5 even though hopefully soon (after ORM 3.x and Symfony 7) we will get compatible with modern Alice abandon this fork.