### PR TITLE
Fix self parameter type resolution

### DIFF
--- a/src/Nelmio/Alice/Loader/Base.php
+++ b/src/Nelmio/Alice/Loader/Base.php
@@ -593,7 +593,19 @@ class Base implements LoaderInterface
             return null;
         }
 
-        return $type->getName();
+        $typeName = $type->getName();
+
+        if ('self' === strtolower($typeName)) {
+            return $parameter->getDeclaringClass()->getName();
+        }
+
+        if ('parent' === strtolower($typeName)) {
+            $parentClass = $parameter->getDeclaringClass()->getParentClass();
+
+            return $parentClass ? $parentClass->getName() : null;
+        }
+
+        return $typeName;
     }
 
     private function process($data, array $variables)

--- a/tests/Nelmio/Alice/Loader/BaseTest.php
+++ b/tests/Nelmio/Alice/Loader/BaseTest.php
@@ -13,6 +13,7 @@ namespace Nelmio\Alice\Loader;
 
 use Nelmio\Alice\TestORM;
 use Nelmio\Alice\Loader\Base;
+use Nelmio\Alice\fixtures\Group;
 use Nelmio\Alice\fixtures\User;
 use PHPUnit\Framework\TestCase;
 
@@ -472,6 +473,28 @@ class BaseTest extends TestCase
         ));
 
         $this->assertSame($owner, $res['group0']->getOwner());
+    }
+
+    public function testLoadFetchesScalarIdsForSelfClassHints()
+    {
+        $relatedGroup = new Group();
+        $orm = $this->createMock('Nelmio\Alice\ORMInterface');
+        $orm->expects($this->once())
+            ->method('find')
+            ->with(self::GROUP, '42')
+            ->willReturn($relatedGroup);
+
+        $loader = $this->createLoader();
+        $loader->setORM($orm);
+        $res = $loader->load(array(
+            self::GROUP => array(
+                'group0' => array(
+                    'relatedGroup' => '42',
+                ),
+            ),
+        ));
+
+        $this->assertSame($relatedGroup, $res['group0']->getRelatedGroup());
     }
 
     public function testLoadParsesFakerData()

--- a/tests/Nelmio/Alice/fixtures/Group.php
+++ b/tests/Nelmio/Alice/fixtures/Group.php
@@ -10,6 +10,7 @@ class Group
     private $members = array();
     private $creationDate;
     private $contactEmail;
+    private $relatedGroup;
     private $supportEmails = array();
     public $contactPerson;
     public $contactPersonName;
@@ -41,6 +42,16 @@ class Group
     public function setOwner(User $owner)
     {
         $this->owner = $owner;
+    }
+
+    public function getRelatedGroup()
+    {
+        return $this->relatedGroup;
+    }
+
+    public function setRelatedGroup(?self $relatedGroup = null)
+    {
+        $this->relatedGroup = $relatedGroup;
     }
 
     public function getMembers()


### PR DESCRIPTION
### Summary
- Resolve PHP `self` parameter types to the declaring class when coercing scalar fixture values through ORM lookup
- Resolve `parent` parameter types to the parent class, matching the old `ReflectionParameter::getClass()` behavior
- Add a regression test for nullable `?self` setters

### Testing
- `vendor/bin/phpunit`